### PR TITLE
特殊运营方式相关修改

### DIFF
--- a/data/SpOp.md
+++ b/data/SpOp.md
@@ -153,6 +153,7 @@
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>南京地铁1号线/10号线（2014.6）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/hz.gif" width="20" hegiht="20"/>杭州地铁1号线/9号线（2021.7）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/gz.gif" width="20" hegiht="20"/>***广州地铁3号线/10号线***
+- <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/gz.gif" width="20" hegiht="20"/>***广州地铁14号线/27号线***
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/cd.gif" width="20" hegiht="20"/>***成都地铁1号线/15号线***
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/suz.gif" width="20" hegiht="20"/>***苏州地铁4号线/7号线***
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/hz.gif" width="20" hegiht="20"/>***杭州地铁6号线/12号线***
@@ -239,6 +240,7 @@
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/sz.gif" width="20" hegiht="20"/>~~深圳地铁3号线~~（2010.12-2011.6）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>~~南京地铁S8线~~（2014.8-2015.4）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/qd.gif" width="20" hegiht="20"/>~~青岛地铁13号线~~（2018.12-2021.12）
+- <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/fs.gif" width="20" hegiht="20"/>~~佛山南海有轨电车1号线~~（2021.8-2022.11）
 
 ### 未成网时互不联通
 #### <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/bj.gif" width="20" hegiht="20"/>北京


### PR DESCRIPTION
1. 新增广州14号线知识城支线拆分
2. 南海新交通（有轨电车1号线）已经入网