### PR TITLE
Update BusPay.md (the part of Hong Kong and Macao)

### DIFF
--- a/data/BusPay.md
+++ b/data/BusPay.md
@@ -347,8 +347,8 @@
 
 | | | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/T-Union.png" width="40" hegiht="40" alt="T-Union"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Unionpay NFC.png" width="40" hegiht="40" alt="Unionpay Quickpass"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Alipay.png" width="30" hegiht="30" alt="Alipay Transit QR Code"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/WeChat Pay.png" width="25" hegiht="25" alt="WeChat Pay Transit QR Code"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Unionpay.png" width="25" hegiht="25" alt="Unionpay Transit QR Code"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Unionpay QR.png" width="40" hegiht="40" alt="Unionpay QR Code"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/contactless.gif" width="40" hegiht="40" alt="Global Cards"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Bus.png" width="25" hegiht="25" alt="Transit QR Code of Additional Apps"/> |
 | :- | :- | :-: | :-: | :-: | :-: | :-: | :-: | :- | :- |
-| **香港/ Hong Kong** | 八达通 | | ⭕[^hk1] | ⭕[^hk] | | ⭕️[^hk1] | | V/M[^hk2] | Alipay HK[^hk] |
-| **澳门/ Macao** | 澳门通 | | ⭕[^mo] | | | | | | 澳门通、上海公共交通卡[^mo2] |
+| **香港/ Hong Kong** | 八达通 | | ⭕[^hk1] | ⭕[^hk] | | ⭕️[^hk1] | | ⭕️[^hk2] | Alipay HK[^hk] |
+| **澳门/ Macao** | 澳门通 | | | | | ⭕[^mo1] | | | 澳门通、城市一卡通[^mo2] |
 
 ### 西南地区/ Southwestern China
 
@@ -510,11 +510,11 @@
 [^kr]: 克拉玛依：仅部分线路支持支付宝、微信和银联的付款码
 [^can]: 广州：仅支持银联手机闪付或银联IC信用卡闪付
 [^can-py]: 广州番禺：仅支持番禺区属路线（番字头）
-[^hk]: 香港：仅龙运巴士所有路线、九巴指定路线、新巴城巴指定路线及部分小巴路线支持
-[^hk1]: 香港：仅龙运巴士所有路线、九巴指定路线及新巴城巴指定路线支持，不支持IC借记卡的非电子现金交易及绑定借记卡的手机闪付
-[^hk2]: 香港：仅龙运巴士所有路线、九巴指定路线及新巴城巴指定路线支持
-[^mo]: 澳门：仅支持电子现金（即内地已经逐渐淘汰的银联脱机闪付），为发卡行当日汇率
-[^mo2]: 澳门：理论上支持所有住建部城市一卡通标准的公交卡，推荐上海公共交通卡（紫卡），经多人测试可用，为卡机设定的固定汇率
+[^hk]: 香港：九巴、龙运、城巴、屿巴路线及部分小巴路线支持
+[^hk1]: 香港：九巴、龙运、城巴路线支持，不支持借记卡或绑定借记卡的手机闪付
+[^hk2]: 香港：九巴、龙运路线支持Visa、Mastercard、JCB、AmEx、Discover/Diners Club。城巴路线支持Visa、Mastercard
+[^mo1]: 澳门：需绑定澳门银行卡的银联澳门乘车码
+[^mo2]: 澳门：理论上支持所有住建部城市一卡通标准的公交卡，推荐上海公共交通卡（Android紫卡/红卡及Apple紫卡），上海、宁波、昆山等多地卡经多人测试可用，为银联当日汇率
 
 [^az]: 阿拉善左旗：巴彦浩特公交仅支持支付宝和微信的付款码
 [^jgdq]: 加格达奇：银联云闪付和银联付款码仅支持建设银行


### PR DESCRIPTION
- 九巴支持AmEX、JCB、Discover/Diners Club。
[電子支付 - 九龍巴士(一九三三) https://www.kmb.hk/payment.html](https://www.kmb.hk/payment.html)
- 城市一卡通于澳门使用汇率为银联当日汇率。
[澳入全國一卡通年内互聯 - 澳門特別行政區政府旅遊局 https://mtt.macaotourism.gov.mo/201601/cn/contents/4/318.html](https://mtt.macaotourism.gov.mo/201601/cn/contents/4/318.html)
- 银联澳门乘车码可用，限绑定澳门银行卡。
[“聚易用+”乘車碼 - 澳門金融管理局 https://www.amcm.gov.mo/zh-hant/news-notice/simplepay/transitcode](https://www.amcm.gov.mo/zh-hant/news-notice/simplepay/transitcode)
- 澳门巴士已停止接受银联闪付电子现金交易。
[關於銀聯閃付卡停用公告 - 澳門通 https://www.macaupass.com/news_detail/752](https://www.macaupass.com/news_detail/752)