### PR TITLE
🛂更新上海数据

### DIFF
--- a/data/Pay.md
+++ b/data/Pay.md
@@ -147,7 +147,7 @@
 | - | - | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/bj.gif" width="20" hegiht="20"/>1100 北京/ Beijing | 🪙1、💴5/10 | ✅ | ✅ | ✅ | ✅ | ⏳ |  |  | ✅ |  |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/tj.gif" width="20" hegiht="20"/>1200 天津/ Tianjin | 🪙1、💴1/5/10/20 |  | ✅ | ✅ | ✅ |  |  |  |  |  |
-| <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/sh.gif" width="20" hegiht="20"/>3100 上海/ Shanghai | 🪙1、💴5/10/20/50 |  | ✅ | ✅ | ✅ |  |  |  |  |  |
+| <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/sh.gif" width="20" hegiht="20"/>3100 上海/ Shanghai | 🪙1、💴5/10/20/50 |  | ✅ | ✅ | ✅ |  | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/contactless_long.gif" width="25" hegiht="25" alt="Global Cards"/> |  |  |  |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/gz.gif" width="20" hegiht="20"/>4401 广州/ Guangzhou | 🪙1、💴5/10 | ✅ | ✅ | ✅ |  |  |  |  | ✅ |  |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/cc.gif" width="20" hegiht="20"/>2201 长春/ Changchun | 🪙1、💴1/5/10 |  | ✅ | ✅ | ✅ |  |  |  |  |  |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/dl.gif" width="20" hegiht="20"/>2102 大连/ Dalian | 🪙1、💴5/10/20 | ⏳ | ✅ | ✅ |  |  |  |  | ✅ |  |


### PR DESCRIPTION
从2024年第二季度开始，上海市地铁人工窗口可以支持国内和国际信用卡支付购票，购票后发放单程票。
通过测试，可以使用中国大陆银联信用卡、美国等国的Visa信用卡/借记卡、香港地区银联借记卡。因此可证明支持国内和国外的多种卡组织的信用卡、借记卡。