### PR TITLE
fix(security): 补充昆明南站高铁换地铁免安检

### DIFF
--- a/data/SecuCk.md
+++ b/data/SecuCk.md
@@ -109,6 +109,9 @@
 ## 5201-贵阳/ Guiyang
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/CR.png" width="15" hegiht="15" alt="China Railway"/>贵阳北/ Guiyangbei/ KQW➡️<img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/gy.gif" width="20" hegiht="20"/>贵阳北站/ Guiyangbei Railway Station
 
+## 5301-昆明/ Kunming
+- <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/CR.png" width="15" hegiht="15" alt="China Railway"/>昆明南/ Kunmingnan/ KOM➡️<img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/km.gif" width="20" hegiht="20"/>昆明南火车站/ Kunming South Railway Station（仅高铁到达换乘地铁1、4号线/ High-speed rail to Metro Lines 1 & 4 only；[来源](https://m.thepaper.cn/baijiahao_32288523)）
+
 ## 6101-西安/ Xi'an
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/CR.png" width="15" hegiht="15" alt="China Railway"/>西安/ Xi'an/ XAY➡️<img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/xa.gif" width="20" hegiht="20"/>西安站/ XI'ANZHAN
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/CR.png" width="15" hegiht="15" alt="China Railway"/>西安北/ Xi'anbei/ EAY➡️<img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/xa.gif" width="20" hegiht="20"/>西安北站/ XI'ANBEIZHAN


### PR DESCRIPTION
## 核验结论

中国铁路昆明局公告确认：自 2025-12-31 起，昆明南站高铁到达旅客可单向免重复安检换乘地铁 1、4 号线；地铁换乘高铁仍按既有流程安检。

## 修改

在 `data/SecuCk.md` 新增昆明南站条目，并注明单向范围和对应线路。

## 依据

中国铁路昆明局：https://m.thepaper.cn/baijiahao_32288523

Closes #138