### PR TITLE
fix(payment): 更新金华云闪付与宁马线状态

### DIFF
--- a/data/Pay.md
+++ b/data/Pay.md
@@ -75,7 +75,7 @@
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nb.gif" width="20" hegiht="20"/>3302 宁波/ Ningbo | 2014 | ✅ | ✅ | ✅ | ✅ | ✅ | | ✅ | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/12306.png" width="20" hegiht="20" alt="12306 App"/> |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/wz.gif" width="20" hegiht="20"/>3303 温州/ Wenzhou | 2019 | ✅ | ✅ | ✅ | | ✅ | | ✅ | |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/sx.gif" width="20" hegiht="20"/>3306 绍兴/ Shaoxing | 2021 | ✅ | ✅ | ✅ | ✅ | ✅ |  |✅ | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/eCNY.png" width="20" hegiht="20" alt="E-CNY"/> |
-| <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/jh.gif" width="20" hegiht="20"/>3307 金华/ Jinhua | 2022 | ⏳ |  | ✅ | |  | | ✅ | |
+| <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/jh.gif" width="20" hegiht="20"/>3307 金华/ Jinhua | 2022 | ⏳ |  | ✅ | | ✅[^jh] | | ✅ | |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/tz.gif" width="20" hegiht="20"/>3310 台州/ Taizhou | 2022 | ✅ | ✅ | ✅ | |  ✅ | | | |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/hf.gif" width="20" hegiht="20"/>3401 合肥/ Hefei | 2016 | ✅ | ✅ | ✅ | ✅ | ✅ | | ✅ | |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/wuh.gif" width="20" hegiht="20"/>3402 芜湖/ Wuhu | 2021 | ✅ | ✅ | ✅ | | ✅ | |✅ | |
@@ -111,7 +111,7 @@
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/ty.gif" width="20" hegiht="20"/>8303 桃园/ Taoyuan | 2017 | | ✅c | ✅ | | | V/M/J | ⭕[^ty] | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Line Pay.png" width="20" hegiht="20" alt="Line Pay"/> |
 | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/tc.gif" width="20" hegiht="20"/>8304 台中/ Taichung | 2021 | | ✅c | | | | V/M/J | | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/TWQR.png" width="20" hegiht="20" alt="TWQR"/> | 
 | | | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/T-Union.png" width="25" hegiht="25" alt="T-Union"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Unionpay NFC.png" width="35" hegiht="35" alt="Unionpay Quickpass"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Alipay.png" width="25" hegiht="25" alt="Alipay"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/WeChat Pay.png" width="20" hegiht="20" alt="WeChat Pay"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Unionpay.png" width="20" hegiht="20" alt="Unionpay App"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/contactless.gif" width="25" hegiht="25" alt="Global Cards"/> | <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/Rail Transit.png" width="20" hegiht="20" alt="Transit Apps"/> | |
-| | | 44/51 | 34/51 | 47/51 | 39/51 | 39/51 | 8/51 | 47/51 | |
+| | | 44/51 | 34/51 | 47/51 | 39/51 | 40/51 | 8/51 | 47/51 | |
 
 [^bj]: 北京：交通联合采用专版白名单（具体参见“交通联合官方服务号”微信公众号）/ Beijing: Special whitelist (see detail in WeChat Official Account) in T-Union
 
@@ -124,6 +124,8 @@
 [^can]: 广州：云闪付乘车码入口为“佛山地铁乘车码”/ Guangzhou: Use Foshan Metro Transit QR in Unionpay App for Guangzhou Metro
 
 [^suz]: 苏州：地铁开通初期的旧版支付宝乘车码已下线，新版于2024年6月重新上线/ Suzhou: New Alipay Transit QR Launched on June 2024
+
+[^jh]: 金华：云闪付App“出行”中领取“金华轨道交通卡”后可使用乘车二维码过闸。来源：金华轨道交通《[乘客指南](http://www.jhmtr.net/rideGuide/)》。
 
 [^hrb]: 哈尔滨：银联闪付仅支持工行、交行、广发、浦发、邮储借记卡及信用卡和招商银行借记卡/ Harbin: Only CMB debit card and debit or credit cards by ICBC, COM, CGB, SPDB, CPG accepted in Quickpass
 

--- a/data/SpOp.md
+++ b/data/SpOp.md
@@ -93,7 +93,7 @@
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/bj.gif" width="20" hegiht="20"/>***北京地铁22号线***（北京&廊坊三河）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/bj.gif" width="20" hegiht="20"/>***北京地铁副中心1号线***（北京&廊坊三河）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/wh.gif" width="20" hegiht="20"/>***武汉地铁11号线***（武汉&鄂州）
-- <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>***南京地铁S2线***（南京&马鞍山）
+- <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>南京地铁S2线（宁马线，南京&马鞍山，2026.4；[来源](https://www.nanjing.gov.cn/zgnjsjb/jrtt/202604/t20260423_5828426.html)）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>***南京地铁S3线***（南京&马鞍山和县）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>***南京地铁S4线***（南京&滁州）
 - <img src="https://raw.githubusercontent.com/Ivysauro/CNRT/master/images/city/nj.gif" width="20" hegiht="20"/>***南京地铁S5线***（南京&扬州）


### PR DESCRIPTION
## 核验结论

- 金华轨道交通乘客指南明确：可在云闪付 App 的“出行”领取“金华轨道交通卡”，并使用乘车二维码过闸。
- 南京市政府确认南京地铁 S2（宁马线）于 2026-04-22 开通初期运营。

## 修改

- 在 `data/Pay.md` 补充金华云闪付乘车码及引用。
- 在 `data/SpOp.md` 将南京地铁 S2 从规划状态更新为已运营，并附官方来源。

## 依据

- 金华轨道交通：https://www.jhmtr.net/rideGuide/
- 南京市政府：https://www.nanjing.gov.cn/zgnjsjb/jrtt/202604/t20260423_5828426.html

Closes #139